### PR TITLE
GetMulti should accept the zero-valued []*S

### DIFF
--- a/get.go
+++ b/get.go
@@ -131,6 +131,9 @@ func GetMulti(c context.Context,
 // unexported in the destination struct. ErrFieldMismatch is only returned if
 // val is a struct pointer.
 func Get(c context.Context, key *datastore.Key, val interface{}) error {
+	if val == nil { // GetMulti catches nil interface; we need to catch nil ptr here
+		return datastore.ErrInvalidEntityType
+	}
 
 	err := GetMulti(c, []*datastore.Key{key}, []interface{}{val})
 	if me, ok := err.(appengine.MultiError); ok {

--- a/nds.go
+++ b/nds.go
@@ -149,5 +149,8 @@ func setValue(val reflect.Value, pl datastore.PropertyList) error {
 	if val.Kind() == reflect.Struct {
 		val = val.Addr()
 	}
+	if val.Kind() == reflect.Ptr && val.Type().Elem().Kind() == reflect.Struct && val.IsNil() {
+		val.Set(reflect.New(val.Type().Elem()))
+	}
 	return datastore.LoadStruct(val.Interface(), pl)
 }


### PR DESCRIPTION
I found that `nds.GetMulti` does not support []*S with nil elements as a destination yet even though `datastore.GetMulti` has supported it since [Go SDK 1.9.18](https://code.google.com/p/googleappengine/wiki/SdkForGoReleaseNotes#Version_1.9.18_-_February_2015). (See https://github.com/golang/appengine/commit/6aa67407028217c352e215f5af320a429d0bcf5f also.)
So I'd like to contribute to adding the support to nds as well.