### PR TITLE
Make memcache use default namespace.

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -41,13 +41,19 @@ func deleteMulti(c context.Context, keys []*datastore.Key) error {
 		lockMemcacheItems = append(lockMemcacheItems, item)
 	}
 
+	memcacheCtx, err := memcacheContext(c)
+	if err != nil {
+		return err
+	}
+
 	// Make sure we can lock memcache with no errors before deleting.
 	if tx, ok := transactionFromContext(c); ok {
 		tx.Lock()
 		tx.lockMemcacheItems = append(tx.lockMemcacheItems,
 			lockMemcacheItems...)
 		tx.Unlock()
-	} else if err := memcacheSetMulti(c, lockMemcacheItems); err != nil {
+	} else if err := memcacheSetMulti(memcacheCtx,
+		lockMemcacheItems); err != nil {
 		return err
 	}
 

--- a/export_test.go
+++ b/export_test.go
@@ -67,3 +67,7 @@ func SetValue(val reflect.Value, pl datastore.PropertyList) error {
 func CreateMemcacheKey(key *datastore.Key) string {
 	return createMemcacheKey(key)
 }
+
+func SetMemcacheNamespace(namespace string) {
+	memcacheNamespace = namespace
+}

--- a/nds.go
+++ b/nds.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"time"
 
+	"golang.org/x/net/context"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/memcache"
@@ -38,7 +39,7 @@ var (
 )
 
 // The variables in this block are here so that we can test all error code
-// paths by substituting the respective functions with error producing ones.
+// paths by substituting them with error producing ones.
 var (
 	datastoreDeleteMulti = datastore.DeleteMulti
 	datastoreGetMulti    = datastore.GetMulti
@@ -52,6 +53,10 @@ var (
 
 	marshal   = marshalPropertyList
 	unmarshal = unmarshalPropertyList
+
+	// memcacheNamespace is the namespace where all memcached entities are
+	// stored.
+	memcacheNamespace = ""
 )
 
 const (
@@ -122,6 +127,10 @@ func createMemcacheKey(key *datastore.Key) string {
 		memcacheKey = hex.EncodeToString(hash[:])
 	}
 	return memcacheKey
+}
+
+func memcacheContext(c context.Context) (context.Context, error) {
+	return appengine.Namespace(c, memcacheNamespace)
 }
 
 func marshalPropertyList(pl datastore.PropertyList) ([]byte, error) {

--- a/nds_test.go
+++ b/nds_test.go
@@ -695,3 +695,31 @@ func TestCreateMemcacheKey(t *testing.T) {
 		t.Fatal("incorrect memcache key size")
 	}
 }
+
+func TestMemcacheNamespace(t *testing.T) {
+
+	c, closeFunc := NewContext(t, nil)
+	defer closeFunc()
+
+	type testEntity struct {
+		IntVal int
+	}
+
+	// Illegal namespace chars.
+	nds.SetMemcacheNamespace("£££")
+
+	key := datastore.NewKey(c, "Entity", "", 1, nil)
+	if err := nds.Get(c, key, &testEntity{}); err == nil {
+		t.Fatal("expected namespace error")
+	}
+
+	if _, err := nds.Put(c, key, &testEntity{}); err == nil {
+		t.Fatal("expected namespace error")
+	}
+
+	if err := nds.Delete(c, key); err == nil {
+		t.Fatal("expected namespace error")
+	}
+
+	nds.SetMemcacheNamespace("")
+}


### PR DESCRIPTION
This fixes bug https://github.com/qedus/nds/issues/42 by ensuring all memcached entities use the default namespace despite the namespace of their respective keys.