### PR TITLE
Create namespaced context memcache locks.

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -36,6 +36,10 @@ func RunInTransaction(c context.Context, f func(tc context.Context) error,
 		// tx.Unlock() is not called as the tx context should never be called
 		//again so we rather block than allow people to misuse the context.
 		tx.Lock()
-		return memcacheSetMulti(tc, tx.lockMemcacheItems)
+		memcacheCtx, err := memcacheContext(tc)
+		if err != nil {
+			return err
+		}
+		return memcacheSetMulti(memcacheCtx, tx.lockMemcacheItems)
 	}, opts)
 }


### PR DESCRIPTION
This commit fixes a bug where memcache locks were not beeing added at
the end of a transaction if the transaction is run in a namespaced
context.