### PR TITLE
Create a new PropertyLoadSaver struct if required.

### DIFF
--- a/get.go
+++ b/get.go
@@ -58,7 +58,7 @@ func GetMulti(c context.Context,
 	keys []*datastore.Key, vals interface{}) error {
 
 	v := reflect.ValueOf(vals)
-	if err := checkMultiArgs(keys, v); err != nil {
+	if err := checkKeysValues(keys, v); err != nil {
 		return err
 	}
 

--- a/get_test.go
+++ b/get_test.go
@@ -1266,3 +1266,16 @@ func TestPropertyLoadSaver(t *testing.T) {
 		t.Fatal("expected another value")
 	}
 }
+
+func TestUnsupportedValueType(t *testing.T) {
+	ctx, closeFunc := NewContext(t)
+	defer closeFunc()
+
+	keys := []*datastore.Key{
+		datastore.NewIncompleteKey(ctx, "Entity", nil),
+	}
+	entities := make([]int, 1)
+	if err := nds.GetMulti(ctx, keys, entities); err == nil {
+		t.Fatal("expected unsupported value error")
+	}
+}

--- a/put.go
+++ b/put.go
@@ -28,7 +28,7 @@ func PutMulti(c context.Context,
 	}
 
 	v := reflect.ValueOf(vals)
-	if err := checkMultiArgs(keys, v); err != nil {
+	if err := checkKeysValues(keys, v); err != nil {
 		return nil, err
 	}
 
@@ -100,7 +100,7 @@ func Put(c context.Context,
 
 	keys := []*datastore.Key{key}
 	vals := []interface{}{val}
-	if err := checkMultiArgs(keys, reflect.ValueOf(vals)); err != nil {
+	if err := checkKeysValues(keys, reflect.ValueOf(vals)); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This fixes #52 by creating a new PropertyLoadSaver struct if required so a datastore entity can be assigned to it.